### PR TITLE
Ignore one-symbol changes

### DIFF
--- a/goggles.el
+++ b/goggles.el
@@ -128,7 +128,7 @@ Zero if characters have been modified.")
 The endpoints of the changed region are pushed to
 the change log `goggles--changes'.
 LEN is the length of the replaced string."
-  (when goggles--active
+  (when (and goggles--active (> (abs len) 1))
     (setq goggles--delta (+ goggles--delta (- end start len)))
     (when (and (/= len 0) (= start end))
       (when (> start (buffer-size))


### PR DESCRIPTION
When non-english input methods are selected quail package does replacement of every char using delete-region function and this triggers advice for highlighting, as a result when you type in non-english input method every single change is highlighed with red.

Ideally quail should be patched to do some inplace edits and avoid triggering edits, but this seems too heavy.
Also, probably avoiding highlight of one symbol changes is not bad anyway